### PR TITLE
2.18.0 BETA4

### DIFF
--- a/snesapu.dll/APU.asm
+++ b/snesapu.dll/APU.asm
@@ -50,7 +50,7 @@ SECTION .data ALIGN=32
 					| (HALFC << 1) | (CNTBK << 2) | (SPEED << 3) | (IPLW << 4) | (DSPBK << 5) | (INTBK << 6)
 	apuDllVer	DD	21800h														;SNESAPU.DLL Current Version
 	apuCmpVer	DD	11000h														;SNESAPU.DLL Backwards Compatible Version
-	apuVerStr	DD	"2.18.0 (build 6674)"										;SNESAPU.DLL Current Version (32byte String)
+	apuVerStr	DD	"2.18.0 (build 6680)"										;SNESAPU.DLL Current Version (32byte String)
 				DD	8
 ; ----- degrade-factory code [END] -----
 
@@ -517,6 +517,7 @@ USES ECX,EDX,EBX,EDI
 	;Emulate APU -----------------------------
 	XOr		EBX,EBX																;Number of samples generated
 	Mov		EDI,[pBuf]
+
 	.Next:
 		Mov		EAX,[cycLeft]
 		Test	EAX,EAX
@@ -525,7 +526,7 @@ USES ECX,EDX,EBX,EDI
 		;SPC700 -------------------------------
 		Mov		EDX,EAX
 		Call	EmuSPC,EAX
-		Mov	[cycLeft],EAX
+		Mov		[cycLeft],EAX
 
 		;DSP ----------------------------------
 		Sub		EDX,EAX															;Calculate number of samples to create
@@ -546,8 +547,8 @@ USES ECX,EDX,EBX,EDI
 
 		Call	EmuDSP,EDI,EAX													;pBuf = EmuDSP(pBuf,samples)
 		Mov		EDI,EAX
-
 		Jmp		short .Next
+
 	.Done:
 
 	;Make sure enough samples were created to fill buffer

--- a/snesapu.dll/DSP.asm
+++ b/snesapu.dll/DSP.asm
@@ -3478,6 +3478,9 @@ ENDP
 ; ----- degrade-factory code [2019/07/21] -----
 ;===================================================================================================
 ;Emulate the KON/KOFF delay processing of DSP
+;
+;Destroys:
+;   EAX,ECX,EDX
 
 %macro CatchKOff 0
 	;KOff process ----------------------
@@ -3485,7 +3488,7 @@ ENDP
 	Test	CL,CL
 	JZ		short %%Done
 
-	Push	EAX,ESI
+	Push	ESI
 
 	Mov		CH,1
 	Mov		EBX,mix
@@ -3519,7 +3522,7 @@ ENDP
 	Add		CH,CH
 	JNZ		%%Next
 
-	Pop		ESI,EAX
+	Pop		ESI
 
 	%%Done:
 %endmacro
@@ -3530,7 +3533,7 @@ ENDP
 	Or		CL,[konRun]
 	JZ		%%Done
 
-	Push	EAX,ESI
+	Push	ESI
 
 	Mov		CL,[konRsv]
 	Mov		CH,1
@@ -3645,7 +3648,7 @@ ENDP
 	Add		CH,CH
 	JNZ		%%Next
 
-	Pop		ESI,EAX
+	Pop		ESI
 
 	%%Done:
 	Mov		[konRsv],CH															;CH = 0
@@ -3668,7 +3671,6 @@ PROC CatchUp
 	Add		[outCnt],EAX
 
 	Push	EDX
-
 	Mul		dword [outRate]
 	Add		EAX,[outDec]
 	AdC		EDX,0
@@ -3691,9 +3693,7 @@ PROC CatchUp
 	Push	ECX																;Run KON/KOFF processing after emulate DSP
 	CatchKOff
 	CatchKOn
-	Pop		ECX
-
-	Pop		EDX
+	Pop		ECX,EDX
 ; ----- degrade-factory code [END] -----
 
 	.Done:

--- a/snesapu.dll/DSP.asm
+++ b/snesapu.dll/DSP.asm
@@ -3475,61 +3475,17 @@ ENDP
 %endmacro
 
 
-;===================================================================================================
-;Emulate DSP
-
-PROC CatchUp
-
-	Push	EAX
-
-	Mov		EAX,[t64Cnt]
-	ShR		EAX,1
-	Sub		EAX,[outCnt]
-	JZ		short .Done
-
-	Add		[outCnt],EAX
-
-	Push	EDX
-	Mul		dword [outRate]
-	Add		EAX,[outDec]
-	AdC		EDX,0
-	Mov		[outDec],AX
-	ShRD	EAX,EDX,16
-	Pop		EDX
-
-	Sub		[outLeft],EAX
-	JNC		short .Okay
-		Add		EAX,[outLeft]
-		Mov		dword [outLeft],0
-
-	.Okay:
-; ----- degrade-factory code [2016/08/20] -----
-	Test	EAX,EAX
-	JZ		short .Done
-		Call	EmuDSP,[pOutBuf],EAX
-		Mov		[pOutBuf],EAX
-; ----- degrade-factory code [END] -----
-
-	.Done:
-	Pop		EAX
-
-ENDP
-
-
-; ----- degrade-factory code [2019/07/07] -----
+; ----- degrade-factory code [2019/07/21] -----
 ;===================================================================================================
 ;Emulate the KON/KOFF delay processing of DSP
 
-PROC CatchKOn
-
-	Push	ECX
-
+%macro CatchKOff 0
 	;KOff process ----------------------
-	MovZX	ECX,byte [dsp+kof]
+	MovZX	ECX,byte [dsp+kof]													;Set CH = 0 for use with CatchKOn
 	Test	CL,CL
-	JZ		short .DoneKOff
+	JZ		short %%Done
 
-	Push	EAX,EDX,ESI
+	Push	EAX,ESI
 
 	Mov		CH,1
 	Mov		EBX,mix
@@ -3537,15 +3493,15 @@ PROC CatchKOn
 	Mov		EDX,[31*4+rateTab]
 	XOr		EAX,EAX
 
-	.NextKOff:
+	%%Next:
 		Test	CL,CH
-		JZ		short .SkipKOff
+		JZ		short %%Skip
 
 		Test	[voiceMix],CH													;Is voice currently playing?
-		JZ		short .SkipKOff													;	No, do nothing
+		JZ		short %%Skip													;	No, do nothing
 
 		Test	byte [EBX+mFlg],MFLG_KOFF										;Is already voice in key off mode?
-		JNZ		short .SkipKOff													;	Yes, do nothing
+		JNZ		short %%Skip													;	Yes, do nothing
 			Mov		byte [EBX+eRIdx],31											;Place envelope in release mode
 			Mov		[EBX+eRate],EDX
 			Mov		[EBX+eCnt],EDX
@@ -3556,34 +3512,36 @@ PROC CatchKOn
 			Mov		[EBX+vRsv],AL												;Reset ADSR/Gain changed flag
 			Mov		[EBX+mKOn],AL												;Reset delay time
 
-		.SkipKOff:
+		%%Skip:
 		Add		ESI,10h
 		Sub		EBX,-80h
 
 	Add		CH,CH
-	JNZ		.NextKOff
+	JNZ		%%Next
 
-	Pop		ESI,EDX,EAX
+	Pop		ESI,EAX
 
-	.DoneKOff:
+	%%Done:
+%endmacro
 
+%macro CatchKOn 0
 	;KOn process -----------------------
 	Mov		CL,[konRsv]
 	Or		CL,[konRun]
-	JZ		.DoneKOn
+	JZ		%%Done
 
-	Push	EAX,EDX,ESI
+	Push	EAX,ESI
 
 	Mov		CL,[konRsv]
 	Mov		CH,1
 	Mov		EBX,mix
 	Mov		ESI,dsp
 
-	.NextKOn:
+	%%Next:
 		Test	byte [EBX+mKOn],-1												;Is already voice in key on mode?
-		JNZ		short .CheckKOff												;	Yes
+		JNZ		short %%CheckKOff												;	Yes
 			Test	CL,CH
-			JZ		.SkipKOn
+			JZ		%%Skip
 
 			XOr		EDX,EDX
 			And		byte [EBX+mFlg],MFLG_USER									;Leave voice muted, noise
@@ -3594,11 +3552,16 @@ PROC CatchKOn
 			Mov		[ESI+outx],DL
 
 			Or		[konRun],CH													;Start KON working
-			Jmp		.SkipKOn
 
-		.CheckKOff:
+			Not		CH
+			And		[dsp+endx],CH												;Clear ENDX register if started KON
+			Not		CH
+
+			Jmp		%%Skip
+
+		%%CheckKOff:
 		Test	[dsp+kof],CH													;Is KOFF still written?
-		JZ		short .CheckEnv													;	No
+		JZ		short %%CheckEnv												;	No
 			Or		byte [EBX+mFlg],MFLG_KOFF									;Flag voice as keying off
 			Mov		byte [EBX+mKOn],0											;Reset delay time
 
@@ -3606,20 +3569,20 @@ PROC CatchKOn
 			And		[konRun],CH													;Cancel KON working
 			Not		CH
 
-			Jmp		.SkipKOn
+			Jmp		%%Skip
 
-		.CheckEnv:
+		%%CheckEnv:
 		Cmp		byte [EBX+mKOn],KON_SAVEENV										;Did time for saved envelope pass after KON had been written?
-		JNE		short .StartKON													;	No
+		JNE		short %%StartKON												;	No
 			Mov		DX,[ESI+adsr]												;Save ADSR parameters
 			Mov		[EBX+vAdsr],DX
 			MovZX	DX,byte [ESI+gain]											;Save Gain parameters
 			Mov		[EBX+vGain],DL
 			Mov		[EBX+vRsv],DH												;Reset ADSR/Gain changed flag
 
-		.StartKON:
+		%%StartKON:
 		Dec		byte [EBX+mKOn]													;Did time for enabled voice pass after KON had been written?
-		JNZ		.SkipKOn														;	No, do nothing
+		JNZ		%%Skip															;	No, do nothing
 			And		byte [EBX+mFlg],MFLG_USER									;Leave voice muted, noise
 
 			;Set voice volume ------------------
@@ -3672,26 +3635,71 @@ PROC CatchKOn
 			Or		[voiceMix],CH												;Mark voice as being on internally
 
 			Not		CH
-			And		[dsp+endx],CH												;Reset the ENDX register
 			And		[konRun],CH													;KON working was finished
 			Not		CH
 
-		.SkipKOn:
+		%%Skip:
 		Add		ESI,10h
 		Sub		EBX,-80h
 
 	Add		CH,CH
-	JNZ		.NextKOn
+	JNZ		%%Next
 
-	Pop		ESI,EDX,EAX
+	Pop		ESI,EAX
 
-	.DoneKOn:
+	%%Done:
 	Mov		[konRsv],CH															;CH = 0
+%endmacro
+; ----- degrade-factory code [END] -----
 
+
+;===================================================================================================
+;Emulate DSP
+
+PROC CatchUp
+
+	Push	EAX
+
+	Mov		EAX,[t64Cnt]
+	ShR		EAX,1
+	Sub		EAX,[outCnt]
+	JZ		.Done
+
+	Add		[outCnt],EAX
+
+	Push	EDX
+
+	Mul		dword [outRate]
+	Add		EAX,[outDec]
+	AdC		EDX,0
+	Mov		[outDec],AX
+	ShRD	EAX,EDX,16
+
+	Sub		[outLeft],EAX
+	JNC		short .Okay
+		Add		EAX,[outLeft]
+		Mov		dword [outLeft],0
+
+	.Okay:
+; ----- degrade-factory code [2019/07/21] -----
+	Test	EAX,EAX
+	JZ		short .Skip
+		Call	EmuDSP,[pOutBuf],EAX
+		Mov		[pOutBuf],EAX
+
+	.Skip:
+	Push	ECX																;Run KON/KOFF processing after emulate DSP
+	CatchKOff
+	CatchKOn
 	Pop		ECX
 
-ENDP
+	Pop		EDX
 ; ----- degrade-factory code [END] -----
+
+	.Done:
+	Pop		EAX
+
+ENDP
 
 
 ;===================================================================================================
@@ -4708,7 +4716,6 @@ PROC RunDSP
 	JNZ		.Mute																;	Yes
 ; ----- degrade-factory code [END] -----
 
-
 	;=========================================
 	; Apply main volumes and mix in echo
 
@@ -4748,7 +4755,6 @@ PROC RunDSP
 	Test	byte [disFlag],40h													;Is DSP emulation disabled? (disFlag = [6])
 	JNZ		.Mute																;	Yes
 ; ----- degrade-factory code [END] -----
-
 
 	;=========================================
 	; Store output

--- a/snesapu.dll/DSP.inc
+++ b/snesapu.dll/DSP.inc
@@ -425,6 +425,3 @@ PUBLIC DSPIn, NULL												;Used internally by SPC700.Asm
 PUBLIC EmuDSP, pBuf:ptr, len:dword
 PUBLIC SetEmuDSP, pBuf:ptr, len:dword, rate:dword				;Used internally by APU.Asm
 PUBLIC CatchUp													;Used internally by SPC700.Asm
-; ----- degrade-factory code [2006/10/17] -----
-PUBLIC CatchKOn													;Used internally by SPC700.Asm
-; ----- degrade-factory code [END] -----

--- a/snesapu.dll/SPC700.asm
+++ b/snesapu.dll/SPC700.asm
@@ -1738,12 +1738,7 @@ SPCTimers:
 
 		.No700:
 %if INTBK && DSPINTEG
-		Call	CatchUp
-
-	Mov		EBX,[t64DSP]
-	And		EBX,1																;Emulate the KON/KOFF processing every 2Ts
-	JNZ		short .NoDSP
-		Call	CatchKOn
+		Call	CatchUp															;Emulate DSP
 %endif
 
 	.NoDSP:

--- a/snesapu.dll/version.rc
+++ b/snesapu.dll/version.rc
@@ -1,5 +1,5 @@
 1 VERSIONINFO
-    FILEVERSION 2,18,0,6674
+    FILEVERSION 2,18,0,6680
     PRODUCTVERSION 2,18,0,0
     FILEFLAGSMASK 0x3fL
     FILEFLAGS 0x8L
@@ -12,7 +12,7 @@ BEGIN
         BLOCK "041103A4"
         BEGIN
             VALUE "FileDescription", "SNES SPC700 Emulator\0"
-            VALUE "FileVersion", "2.18.0 (build 6674)\0"
+            VALUE "FileVersion", "2.18.0 (build 6680)\0"
             VALUE "LegalCopyright", "Copyright (C) 1999-2008 Alpha-II Productions; (C) 2003-2019 degrade-factory.\0"
             VALUE "LegalTrademarks", "SNES is a registered trademark of Nintendo.\0"
             VALUE "ProductName", "SNESAPU\0"

--- a/spcplay.exe/spcplay.dpr
+++ b/spcplay.exe/spcplay.dpr
@@ -2325,7 +2325,7 @@ const
     DEFAULT_TITLE: string = 'SNES SPC700 Player';
     SPCPLAY_TITLE = '[ SNES SPC700 Player   ]' + CRLF + ' SPCPLAY.EXE v';
     SNESAPU_TITLE = '[ SNES SPC700 Emulator ]' + CRLF + ' SNESAPU.DLL v';
-    SPCPLAY_VERSION = '2.18.0 (build 6674)';
+    SPCPLAY_VERSION = '2.18.0 (build 6680)';
     SNESAPU_VERSION = $21800;
     APPLINK_VERSION = $02170500;
 

--- a/spcplay.exe/spcplay.rc
+++ b/spcplay.exe/spcplay.rc
@@ -2,7 +2,7 @@ MAINICON ICON DISCARDABLE "spcplay.ico"
 MAINBMP BITMAP DISCARDABLE "spcplay.bmp"
 
 1 VERSIONINFO
-    FILEVERSION 2,18,0,6674
+    FILEVERSION 2,18,0,6680
     PRODUCTVERSION 2,18,0,0
     FILEFLAGSMASK 0x3fL
     FILEFLAGS 0x8L
@@ -15,7 +15,7 @@ BEGIN
         BLOCK "041103A4"
         BEGIN
             VALUE "FileDescription", "SNES SPC700 Player\0"
-            VALUE "FileVersion", "2.18.0 (build 6674)\0"
+            VALUE "FileVersion", "2.18.0 (build 6680)\0"
             VALUE "LegalCopyright", "Copyright (C) 2003-2019 degrade-factory.\0"
             VALUE "LegalTrademarks", "SNES is a registered trademark of Nintendo.\0"
             VALUE "ProductName", "SPCPLAY\0"


### PR DESCRIPTION
snesapu.dll
* KON/KOFF 処理をマクロ化（グローバル参照が1つ減った）
* ENDX フラグの初期化タイミングを調整