### PR TITLE
2.18.0 BETA5

### DIFF
--- a/snesapu.dll/APU.asm
+++ b/snesapu.dll/APU.asm
@@ -50,7 +50,7 @@ SECTION .data ALIGN=32
 					| (HALFC << 1) | (CNTBK << 2) | (SPEED << 3) | (IPLW << 4) | (DSPBK << 5) | (INTBK << 6)
 	apuDllVer	DD	21800h														;SNESAPU.DLL Current Version
 	apuCmpVer	DD	11000h														;SNESAPU.DLL Backwards Compatible Version
-	apuVerStr	DD	"2.18.0 (build 6680)"										;SNESAPU.DLL Current Version (32byte String)
+	apuVerStr	DD	"2.18.0 (build 6694)"										;SNESAPU.DLL Current Version (32byte String)
 				DD	8
 ; ----- degrade-factory code [END] -----
 

--- a/snesapu.dll/DSP.inc
+++ b/snesapu.dll/DSP.inc
@@ -70,7 +70,7 @@ MFLG_KOFF	EQU	04h												;Voice is in the process of keying off
 MFLG_OFF	EQU	08h												;Voice is currently inactive
 MFLG_END	EQU	10h												;End block was just played
 
-; ----- degrade-factory code [2019/07/07] -----
+; ----- degrade-factory code [2019/08/04] -----
 ;Script700 DSP flags
 S700_MUTE	EQU	01h												;Mute voice
 S700_CHANGE	EQU	02h												;Change sound source (note change)
@@ -85,6 +85,7 @@ S700_ECHO_R	EQU	03h												;Echo volume (right)
 
 ;DSP KON delay emulation time
 KON_DELAY	EQU	19												;Delay time from writing KON to output (40Ts / 2 - 1)
+KON_CHKKOFF	EQU	1												;Delay time from checking KOFF, if DSPBK is 1
 KON_SAVEENV	EQU	KON_DELAY										;Delay time from writing save envelope to output
 ; ----- degrade-factory code [END] -----
 

--- a/snesapu.dll/SPC700.asm
+++ b/snesapu.dll/SPC700.asm
@@ -2226,7 +2226,7 @@ Ret
 ;         bit-0 Data written was 16-bit
 %macro WrPost 1
 
-%if	%1 & 80h
+%if %1 & 80h
 	Cmp		BX,ipl																;Was memory in the IPL ROM region modified?
 	JAE		short %%WROM														;	Yes
 %endif
@@ -2246,7 +2246,7 @@ Ret
 		MovZX	EBX,CL
 		Mov		EBX,[fncOfs+EBX*4]
 ; ----- degrade-factory code [END] -----
-%if	%1 & 1
+%if %1 & 1
 ; ----- degrade-factory code [2007/10/07] -----
 		Push	EBX																;Save low function register handler
 		Inc		CL																;Jump to next function register
@@ -2257,7 +2257,7 @@ Ret
 %endif
 		Jmp		EBX
 
-%if	%1 & 80h
+%if %1 & 80h
 	%%WROM:
 %if IPLW
 		Test	byte [tControl],80h												;Is ROM reading enabled?

--- a/snesapu.dll/SPC700.inc
+++ b/snesapu.dll/SPC700.inc
@@ -50,7 +50,7 @@ FCH_PAUSE	EQU	03h
 ; ----- degrade-factory code [END] -----
 
 ; ----- degrade-factory code [2010/04/03] -----
-%ifdef	SHVC_SOUND_SUPPORT
+%ifdef SHVC_SOUND_SUPPORT
 ;Extend function pointer address ------------
 EXT_WRPORT	EQU	10014h											;Callback function to write port
 EXT_RDPORT	EQU	10018h											;Callback function to read port

--- a/snesapu.dll/version.rc
+++ b/snesapu.dll/version.rc
@@ -1,5 +1,5 @@
 1 VERSIONINFO
-    FILEVERSION 2,18,0,6680
+    FILEVERSION 2,18,0,6694
     PRODUCTVERSION 2,18,0,0
     FILEFLAGSMASK 0x3fL
     FILEFLAGS 0x8L
@@ -12,7 +12,7 @@ BEGIN
         BLOCK "041103A4"
         BEGIN
             VALUE "FileDescription", "SNES SPC700 Emulator\0"
-            VALUE "FileVersion", "2.18.0 (build 6680)\0"
+            VALUE "FileVersion", "2.18.0 (build 6694)\0"
             VALUE "LegalCopyright", "Copyright (C) 1999-2008 Alpha-II Productions; (C) 2003-2019 degrade-factory.\0"
             VALUE "LegalTrademarks", "SNES is a registered trademark of Nintendo.\0"
             VALUE "ProductName", "SNESAPU\0"

--- a/spcplay.exe/spcplay.dpr
+++ b/spcplay.exe/spcplay.dpr
@@ -2968,7 +2968,7 @@ const
     STR_MENU_FILE_EXIT: array[0..1] of pchar = ('終了(&X)', 'E&xit');
     STR_MENU_SETUP_DEVICE: array[0..1] of pchar = ('サウンド デバイス(&D)', 'Sound &Devices');
     STR_MENU_SETUP_CHANNEL: array[0..1] of pchar = ('チャンネル(&C)', '&Channels');
-    STR_MENU_SETUP_BIT: array[0..1] of pchar = ('ビット(&B)', '&Bits');
+    STR_MENU_SETUP_BIT: array[0..1] of pchar = ('ビット(&B)', '&Bit');
     STR_MENU_SETUP_RATE: array[0..1] of pchar = ('サンプリング レート(&R)', 'Sampling &Rate');
     STR_MENU_SETUP_INTER: array[0..1] of pchar = ('補間処理(&I)', '&Interpolation');
     STR_MENU_SETUP_PITCH: array[0..1] of pchar = ('ピッチ(&P)', '&Pitch');
@@ -3022,7 +3022,7 @@ const
         ('&1 Channel  (Monaural)', '&2 Channels  (Stereo)'));
     STR_MENU_SETUP_BIT_SUB: array[0..1] of array[0..MENU_SETUP_BIT_SIZE - 1] of pchar = (
         ('&8 ビット', Concat('&16 ビット', #9, '［標準］'), '&24 ビット', '&32 ビット  (int)', Concat('&32 ビット  (float)', #9, '［高音質］')),
-        ('&8 Bits', Concat('&16 Bits', #9, '[Normal]'), '&24 Bits', '&32 Bits  (int)', Concat('&32 Bits  (float)', #9, '[HQ]')));
+        ('&8-Bit', Concat('&16-Bit', #9, '[Normal]'), '&24-Bit', '&32-Bit  (int)', Concat('&32-Bit  (float)', #9, '[HQ]')));
     STR_MENU_SETUP_RATE_SUB: array[0..1] of array[0..MENU_SETUP_RATE_SIZE - 1] of pchar = (
         ('&8,000 Hz', '&10,000 Hz', '&11,025 Hz', '&12,000 Hz', '&16,000 Hz', '&20,000 Hz', '&22,050 Hz', '&24,000 Hz', Concat('&32,000 Hz', #9, '［推奨］'), '&40,000 Hz', '&44,100 Hz', '&48,000 Hz', '&64,000 Hz', '&80,000 Hz', '&88,200 Hz', '&96,000 Hz'),
         ('&8,000 Hz', '&10,000 Hz', '&11,025 Hz', '&12,000 Hz', '&16,000 Hz', '&20,000 Hz', '&22,050 Hz', '&24,000 Hz', Concat('&32,000 Hz', #9, '[Recommend]'), '&40,000 Hz', '&44,100 Hz', '&48,000 Hz', '&64,000 Hz', '&80,000 Hz', '&88,200 Hz', '&96,000 Hz'));

--- a/spcplay.exe/spcplay.dpr
+++ b/spcplay.exe/spcplay.dpr
@@ -2325,7 +2325,7 @@ const
     DEFAULT_TITLE: string = 'SNES SPC700 Player';
     SPCPLAY_TITLE = '[ SNES SPC700 Player   ]' + CRLF + ' SPCPLAY.EXE v';
     SNESAPU_TITLE = '[ SNES SPC700 Emulator ]' + CRLF + ' SNESAPU.DLL v';
-    SPCPLAY_VERSION = '2.18.0 (build 6680)';
+    SPCPLAY_VERSION = '2.18.0 (build 6694)';
     SNESAPU_VERSION = $21800;
     APPLINK_VERSION = $02170500;
 

--- a/spcplay.exe/spcplay.rc
+++ b/spcplay.exe/spcplay.rc
@@ -2,7 +2,7 @@ MAINICON ICON DISCARDABLE "spcplay.ico"
 MAINBMP BITMAP DISCARDABLE "spcplay.bmp"
 
 1 VERSIONINFO
-    FILEVERSION 2,18,0,6680
+    FILEVERSION 2,18,0,6694
     PRODUCTVERSION 2,18,0,0
     FILEFLAGSMASK 0x3fL
     FILEFLAGS 0x8L
@@ -15,7 +15,7 @@ BEGIN
         BLOCK "041103A4"
         BEGIN
             VALUE "FileDescription", "SNES SPC700 Player\0"
-            VALUE "FileVersion", "2.18.0 (build 6680)\0"
+            VALUE "FileVersion", "2.18.0 (build 6694)\0"
             VALUE "LegalCopyright", "Copyright (C) 2003-2019 degrade-factory.\0"
             VALUE "LegalTrademarks", "SNES is a registered trademark of Nintendo.\0"
             VALUE "ProductName", "SPCPLAY\0"


### PR DESCRIPTION
spcplay.exe
* 英語のビット表記を修正

snesapu.dll
* CNTBK, DSPBK を 1 にセットした場合、クラッシュするバグ修正