### PR TITLE
v2.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,46 +3,50 @@
 ## 概要
 
 SNES SPC700 Player と改良版 SNESAPU.DLL 一式のソースコードです。  
-アプリの詳細については、[デグレファクトリーのサイト](https://dgrfactory.jp/spcplay/index.html)をご覧ください。
+アプリの詳細については、[デグレファクトリーのサイト (日本語)](https://dgrfactory.jp/spcplay/index.html) をご覧ください。
 
-## spcplay.exe
+## Overview
 
-**SNES SPC700 Player:**  
-スーパーファミコンの音楽ファイル (SPC) をパソコン上で再生するための SPC 専用プレイヤーです。  
-Win32API を直接使用しているので、軽量・軽快に動作します。
+Source codes of SNES SPC700 Player and improved SNESAPU.DLL.  
+If you want to see details of this software, please visit [release page (in English)](https://github.com/dgrfactory/spcplay/releases).
 
-コンパイルに必要なソフト： dcc32 (Delphi6 UP2 RTL3 で動作確認済)
+## How to build
+
+### spcplay.exe
+
+Frontend for using SNESAPU.DLL.  
+Required software: dcc32 (Delphi6 UP2 RTL3)
 
 ```
 rc.exe /l 0x411 /fo spcplay.res /d "NDEBUG" spcplay.rc
 dcc32.exe spcplay.dpr
 ```
 
-## snesapu.dll
+### snesapu.dll
 
-**改良版SNESAPU.DLL:**  
-再現性と音質に定評がある Alpha-II Productions 製の SNESAPU.DLL v2.0 をベースに、最新版 v3.0 の一部機能や独自拡張機能を取り込んでいます。
-
-コンパイルに必要なソフト： VC++ (VC++6 SP6 で動作確認済), nasm (Netwide Assembler)
+SNES SPC700 emulator. (forks from [Alpha-II Productions](https://www.alpha-ii.com/))  
+Required softwares: VC++ (VC++6 SP6), nasm (Netwide Assembler)
 
 ```
 nasm.exe -D WIN32 -D STDCALL -O2 -w-macro-params -f win32 -o .\Release\SPC700.obj SPC700.asm
 nasm.exe -D WIN32 -D STDCALL -O2 -w-macro-params -f win32 -o .\Release\DSP.obj DSP.asm
 nasm.exe -D WIN32 -D STDCALL -O2 -w-macro-params -f win32 -o .\Release\APU.obj APU.asm
-rc.exe /l 0x411 /fo Release\version.res /d "NDEBUG" version.rc
+rc.exe /l 0x411 /fo .\Release\version.res /d "NDEBUG" version.rc
 cl.exe @option\snesapu-cl.txt
 link.exe @option\snesapu-link.txt
 ```
 
-※他プレイヤー用をビルドする場合は、thirdparty ディレクトリの中身を本体にコピーして、snesapu-link.txt の代わりに snesapu-3rd-link.txt を使用。
+for 3rd-party players:
+```
+cp -r thirdparty/* ./
+  : (nasm, rc, cl)
+link.exe @option\snesapu-3rd-link.txt
+```
 
-## spccmd.exe
+### spccmd.exe
 
-**SNES SPC700 Player 外部コマンド拡張ツール:**  
-SNES SPC700 Player をコマンドラインで操作するアプリです。  
-コマンドによる再生・停止操作、SPC700 や DSP のデバッグ、G.I.M.I.C 等の転送プログラムのシミュレーション等が行えます。
-
-コンパイルに必要なソフト： dcc32 (Delphi6 UP2 RTL3 で動作確認済)
+Software that operates spcplay.exe on the command line.  
+Required software: dcc32 (Delphi6 UP2 RTL3)
 
 ```
 rc.exe /l 0x411 /fo spccmd.res /d "NDEBUG" spccmd.rc

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ link.exe @option\snesapu-link.txt
 
 for 3rd-party players:
 ```
-cp -r thirdparty/* ./
+copy /y thirdparty\* .
   : (nasm, rc, cl)
 link.exe @option\snesapu-3rd-link.txt
 ```

--- a/snesapu.dll/APU.asm
+++ b/snesapu.dll/APU.asm
@@ -19,7 +19,7 @@
 ;59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 ;
 ;                                                   Copyright (C) 2003-2006 Alpha-II Productions
-;                                                   Copyright (C) 2003-2019 degrade-factory
+;                                                   Copyright (C) 2003-2020 degrade-factory
 ;===================================================================================================
 
 CPU		386
@@ -48,9 +48,9 @@ SECTION .data ALIGN=32
 ; ----- degrade-factory code [2019/07/15] -----
 	apuOpt		DD	(CPU_CYC << 24) | (DEBUG << 16) | (DSPINTEG << 17) | (VMETERM << 8) | (VMETERV << 9) | (1 << 10) | (STEREO << 11) \
 					| (HALFC << 1) | (CNTBK << 2) | (SPEED << 3) | (IPLW << 4) | (DSPBK << 5) | (INTBK << 6)
-	apuDllVer	DD	21800h														;SNESAPU.DLL Current Version
+	apuDllVer	DD	21861h														;SNESAPU.DLL Current Version
 	apuCmpVer	DD	11000h														;SNESAPU.DLL Backwards Compatible Version
-	apuVerStr	DD	"2.18.0 (build 6694)"										;SNESAPU.DLL Current Version (32byte String)
+	apuVerStr	DD	"2.18.1 (build 6862)"										;SNESAPU.DLL Current Version (32byte String)
 				DD	8
 ; ----- degrade-factory code [END] -----
 

--- a/snesapu.dll/version.rc
+++ b/snesapu.dll/version.rc
@@ -1,6 +1,6 @@
 1 VERSIONINFO
-    FILEVERSION 2,18,0,6694
-    PRODUCTVERSION 2,18,0,0
+    FILEVERSION 2,18,1,6862
+    PRODUCTVERSION 2,18,1,0
     FILEFLAGSMASK 0x3fL
     FILEFLAGS 0x8L
     FILEOS 0x10004L
@@ -12,11 +12,11 @@ BEGIN
         BLOCK "041103A4"
         BEGIN
             VALUE "FileDescription", "SNES SPC700 Emulator\0"
-            VALUE "FileVersion", "2.18.0 (build 6694)\0"
-            VALUE "LegalCopyright", "Copyright (C) 1999-2008 Alpha-II Productions; (C) 2003-2019 degrade-factory.\0"
+            VALUE "FileVersion", "2.18.1 (build 6862)\0"
+            VALUE "LegalCopyright", "Copyright (C) 1999-2008 Alpha-II Productions; (C) 2003-2020 degrade-factory.\0"
             VALUE "LegalTrademarks", "SNES is a registered trademark of Nintendo.\0"
             VALUE "ProductName", "SNESAPU\0"
-            VALUE "ProductVersion", "2.18.0\0"
+            VALUE "ProductVersion", "2.18.1\0"
             VALUE "URL", "http://dgrfactory.jp/\0"
         END
     END

--- a/spccmd.exe/spccmd.dpr
+++ b/spccmd.exe/spccmd.dpr
@@ -44,7 +44,7 @@
 //  ※ GNU 一般公衆利用許諾契約書バージョン 2 のドキュメントは、付属の LICENSE にあります。
 //
 //
-//  Copyright (C) 2003-2019 degrade-factory. All rights reserved.
+//  Copyright (C) 2003-2020 degrade-factory. All rights reserved.
 //
 // =================================================================================================
 program spccmd;
@@ -151,13 +151,13 @@ const
     CLASS_NAME: string = 'SSDLabo_SPCPLAY';
     SPC_FILE_HEADER = 'SNES-SPC700 Sound File Data ';
     SPC_FILE_HEADER_LEN = 28;
-    SPCCMD_VERSION = '1.5.0 (build 4062)';
+    SPCCMD_VERSION = '1.5.1 (build 4212)';
     APPLINK_VERSION = $02170500;
     HexTable: array[0..15] of char = ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F');
     INI_FILE: string = 'spcplay.ini';
     BUFFER_LENGTH = 13;
     BUFFER_START = BUFFER_LENGTH + 1;
-    BUFFER_LANGUAGE: string = 'LANGUAGE 0 : ';
+    BUFFER_LANGUAGE: string = 'LANGUAGE 1 : ';
     LIST_FILE: string = 'spcplay.stk';
     LIST_FILE_HEADER_A: string = 'SSDLabo Spcplay ListFile v1.0';
     LIST_FILE_HEADER_A_LEN = 29;
@@ -195,6 +195,10 @@ const
     OPEN_EXISTING = $3;
     OPEN_ALWAYS = $4;
     TRUNCATE_EXISTING = $5;
+
+    LOCALE_AUTO = 0;                                        // 自動
+    LOCALE_JA = 1;                                          // 日本語
+    LOCALE_EN = 2;                                          // 英語
 
     WM_COMMAND = $111;
     MENU_FILE_PLAY_BASE = 110;
@@ -248,62 +252,62 @@ const
     STATUS_PAUSE = $4;                                      // Pause フラグ
 
     STR_VERSION_1: array[0..1] of string = ('SNES SPC700 Player 外部拡張コマンド ツール', 'SNES SPC700 Player external command tool');
-    STR_VERSION_2: array[0..1] of string = ('サポートしている SPCPLAY.EXE のバージョン： v2.17.7 以降', 'Supported SPCPLAY.EXE version: v2.17.7 or later');
+    STR_VERSION_2: array[0..1] of string = ('サポートしている SPCPLAY.EXE のバージョン： v2.18.0 以降', 'Supported SPCPLAY.EXE version: v2.18.0 or later');
 
     STR_USAGE_TITLE: array[0..1] of string = ('<< 構文 >>', '<< USAGE >>');
     STR_USAGE_NEXT: array[0..1] of string = ('Enter キーで続きを表示します...', 'Press Enter key to continue...');
     STR_USAGE_COMMAND: array[0..1] of string = ('  spccmd.exe [オプション]', '  spccmd.exe [option]');
     STR_USAGE_OPTION: array[0..1] of string = ('[オプション]', '[option]');
-    STR_USAGE_OPTION_BASE: array[0..1] of string = ('基本オプション', 'Base Option');
+    STR_USAGE_OPTION_BASE: array[0..1] of string = ('基本オプション', 'Base options');
     STR_USAGE_OPTION_BASE_H: array[0..1] of string = ('構文ヘルプを表示', 'Show usage');
     STR_USAGE_OPTION_BASE_V: array[0..1] of string = ('バージョン情報を表示', 'Show version');
     STR_USAGE_OPTION_BASE_P: array[0..1] of string = ('演奏開始・一時停止', 'Play/Pause');
     STR_USAGE_OPTION_BASE_R: array[0..1] of string = ('最初から演奏', 'Restart');
     STR_USAGE_OPTION_BASE_S: array[0..1] of string = ('演奏停止', 'Stop');
-    STR_USAGE_OPTION_DSP: array[0..1] of string = ('DSP レジスタ値の読取・書込', 'Read/Write DSP Register');
-    STR_USAGE_OPTION_DSP_G: array[0..1] of string = ('読取 <XX>(アドレス) = $00～$7F', 'Read  <XX>(Address) = $00-$7F');
-    STR_USAGE_OPTION_DSP_S: array[0..1] of string = ('書込 <YY>(値) = $00～$FF (8bit)', 'Write <YY>(Value) = $00-$FF (8bit)');
+    STR_USAGE_OPTION_DSP: array[0..1] of string = ('DSP レジスタ値の読取・書込', 'Read/Write DSP registers');
+    STR_USAGE_OPTION_DSP_G: array[0..1] of string = ('読取   <XX>(アドレス) = $00～$7F', 'Read    <XX>(Address) = $00-$7F');
+    STR_USAGE_OPTION_DSP_S: array[0..1] of string = ('書込   <YY>(値) = $00～$FF (8bit)', 'Write   <YY>(Value) = $00-$FF (8bit)');
     STR_USAGE_OPTION_DSP_M: array[0..1] of string = ('DSP レジスタ メモリマップ表示', 'Show DSP Register Memory Map');
-    STR_USAGE_OPTION_PORT: array[0..1] of string = ('SPC700 I/O ポート値の読取・書込', 'Read/Write I/O Port');
-    STR_USAGE_OPTION_PORT_G: array[0..1] of string = ('読取 <XX>(アドレス) = 0～3', 'Read  <XX>(Address) = 0-3');
-    STR_USAGE_OPTION_PORT_S: array[0..1] of string = ('書込 <YY>(値) = $00～$FF (8bit)', 'Write <YY>(Value) = $00-$FF (8bit)');
+    STR_USAGE_OPTION_PORT: array[0..1] of string = ('SPC700 I/O ポート値の読取・書込', 'Read/Write I/O ports');
+    STR_USAGE_OPTION_PORT_G: array[0..1] of string = ('読取   <XX>(アドレス) = 0～3', 'Read    <XX>(Address) = 0-3');
+    STR_USAGE_OPTION_PORT_S: array[0..1] of string = ('書込   <YY>(値) = $00～$FF (8bit)', 'Write   <YY>(Value) = $00-$FF (8bit)');
     STR_USAGE_OPTION_PORT_T: array[0..1] of string = ('値を書込後すぐに元の値に戻す', 'Test write mode');
     STR_USAGE_OPTION_RAM: array[0..1] of string = ('64KB APU RAM の読取・書込', 'Read/Write 64KB APU RAM');
-    STR_USAGE_OPTION_RAM_G: array[0..1] of string = ('読取 <XX>(アドレス) = $0000～$FFFF', 'Read  <XX>(Address) = $0000-$FFFF');
-    STR_USAGE_OPTION_RAM_S: array[0..1] of string = ('書込 <YY>(値) = $00000000～$FFFFFFFF (32bit)', 'Write <YY>(Value) = $00000000-$FFFFFFFF (32bit)');
+    STR_USAGE_OPTION_RAM_G: array[0..1] of string = ('読取   <XX>(アドレス) = $0000～$FFFF', 'Read    <XX>(Address) = $0000-$FFFF');
+    STR_USAGE_OPTION_RAM_S: array[0..1] of string = ('書込   <YY>(値) = $00000000～$FFFFFFFF (32bit)', 'Write   <YY>(Value) = $00000000-$FFFFFFFF (32bit)');
     STR_USAGE_OPTION_RAM_M: array[0..1] of string = ('APU RAM メモリマップ表示 <ZZ>(表示量)', 'Show Memory Map <ZZ>(Table size)');
-    STR_USAGE_OPTION_WORK: array[0..1] of string = ('Script700 Work の読取・書込', 'Read/Write Script700 Work');
-    STR_USAGE_OPTION_WORK_G: array[0..1] of string = ('読取 <XX>(アドレス) = 0～7', 'Read  <XX>(Address) = 0-7');
-    STR_USAGE_OPTION_WORK_S: array[0..1] of string = ('書込 <YY>(値) = $00000000～$FFFFFFFF (32bit)', 'Write <YY>(Value) = $00000000-$FFFFFFFF (32bit)');
-    STR_USAGE_OPTION_CMP: array[0..1] of string = ('Script700 CmpParam の読取・書込', 'Read/Write Script700 Cmp Param');
-    STR_USAGE_OPTION_CMP_G: array[0..1] of string = ('読取 <XX>(アドレス) = 0／1', 'Read  <XX>(Address) = 0/1');
-    STR_USAGE_OPTION_CMP_S: array[0..1] of string = ('書込 <YY>(値) = $00000000～$FFFFFFFF (32bit)', 'Write <YY>(Value) = $00000000-$FFFFFFFF (32bit)');
-    STR_USAGE_OPTION_SPC: array[0..1] of string = ('SPC700 レジスタ値の読取・書込', 'Read/Write SPC700 Register');
-    STR_USAGE_OPTION_SPC_G: array[0..1] of string = ('読取 <XX>(0=PC, 1=Y+A, 2=SP+X, 3:PSW)', 'Read  <XX>(0=PC, 1=Y+A, 2=SP+X, 3:PSW)');
-    STR_USAGE_OPTION_SPC_S: array[0..1] of string = ('書込 <YY>(値) = $0000～$FFFF (16bit)', 'Write <YY>(Value) = $0000-$FFFF (16bit)');
-    STR_USAGE_OPTION_HALT: array[0..1] of string = ('エミュレーション動作', 'Emulation running');
+    STR_USAGE_OPTION_WORK: array[0..1] of string = ('Script700 Work の読取・書込', 'Read/Write Script700 working memories');
+    STR_USAGE_OPTION_WORK_G: array[0..1] of string = ('読取   <XX>(アドレス) = 0～7', 'Read    <XX>(Address) = 0-7');
+    STR_USAGE_OPTION_WORK_S: array[0..1] of string = ('書込   <YY>(値) = $00000000～$FFFFFFFF (32bit)', 'Write   <YY>(Value) = $00000000-$FFFFFFFF (32bit)');
+    STR_USAGE_OPTION_CMP: array[0..1] of string = ('Script700 CmpParam の読取・書込', 'Read/Write Script700 CMP parameters');
+    STR_USAGE_OPTION_CMP_G: array[0..1] of string = ('読取   <XX>(アドレス) = 0／1', 'Read    <XX>(Address) = 0/1');
+    STR_USAGE_OPTION_CMP_S: array[0..1] of string = ('書込   <YY>(値) = $00000000～$FFFFFFFF (32bit)', 'Write   <YY>(Value) = $00000000-$FFFFFFFF (32bit)');
+    STR_USAGE_OPTION_SPC: array[0..1] of string = ('SPC700 レジスタ値の読取・書込', 'Read/Write SPC700 registers');
+    STR_USAGE_OPTION_SPC_G: array[0..1] of string = ('読取   <XX>(0=PC, 1=Y+A, 2=SP+X, 3:PSW)', 'Read    <XX>(0=PC, 1=Y+A, 2=SP+X, 3:PSW)');
+    STR_USAGE_OPTION_SPC_S: array[0..1] of string = ('書込   <YY>(値) = $0000～$FFFF (16bit)', 'Write   <YY>(Value) = $0000-$FFFF (16bit)');
+    STR_USAGE_OPTION_HALT: array[0..1] of string = ('エミュレーション動作', 'Set emulation flags');
     STR_USAGE_OPTION_HALT_S1: array[0..1] of string = ('<XX>(1=SPC_RETURN, 2=SPC_HALT, 4=DSP_HALT, 8=SPC_NODSP,', '<XX>(1=SPC_RETURN, 2=SPC_HALT, 4=DSP_HALT, 8=SPC_NODSP,');
     STR_USAGE_OPTION_HALT_S2: array[0..1] of string = ('     32=DSP_PAUSE, 34=SPC_HALT+DSP_PAUSE)', '     32=DSP_PAUSE, 34=SPC_HALT+DSP_PAUSE)');
-    STR_USAGE_OPTION_BP: array[0..1] of string = ('SPC700 ブレイクポイント', 'SPC700 Break Point');
+    STR_USAGE_OPTION_BP: array[0..1] of string = ('SPC700 ブレイクポイント', 'SPC700 break points');
     STR_USAGE_OPTION_BP_X: array[0..1] of string = ('<XX>(アドレス) = $0000～$FFFF', '<XX>(Address) = $0000-$FFFF');
     STR_USAGE_OPTION_BP_Y: array[0..1] of string = ('<YY>(0=解除, 1>=設定※)', '<YY>(0=UNSET, 1>=SET *)');
-    STR_USAGE_OPTION_BPAC: array[0..1] of string = ('ブレイクポイント全解除', 'Break Point ALL clear');
+    STR_USAGE_OPTION_BPAC: array[0..1] of string = ('ブレイクポイント全解除', 'All clear break points');
     STR_USAGE_OPTION_NEXT: array[0..1] of string = ('次へ進む', 'Next tick');
-    STR_USAGE_OPTION_NEXT_X: array[0..1] of string = ('<XX>(0=次のBPまで, 1>=次の命令まで※)', '<XX>(0=Next BP, 1>=Next Operate *)');
+    STR_USAGE_OPTION_NEXT_Z: array[0..1] of string = ('<ZZ>(0=次のBPまで, 1>=次の命令まで※)', '<XX>(0=Next BP, 1>=Next Operate *)');
     STR_USAGE_OPTION_STOP_FLAGS: array[0..1] of string = ('  ※停止方法：1=SPC_HALT, 2=NOP, 3=SPC_HALT+DSP_PAUSE', '    * How to stop: 1=SPC_HALT, 2=NOP, 3=SPC_HALT+DSP_PAUSE');
-    STR_USAGE_OPTION_DSPC: array[0..1] of string = ('DSP チート', 'DSP cheat');
+    STR_USAGE_OPTION_DSPC: array[0..1] of string = ('DSP チート', 'DSP cheats');
     STR_USAGE_OPTION_DSPC_X: array[0..1] of string = ('<XX>(アドレス) = $00～$7F', '<XX>(Address) = $00-$7F');
     STR_USAGE_OPTION_DSPC_Y: array[0..1] of string = ('<YY>(値) = $00～$FF (8bit), $100>=解除', '<YY>(Value) = $00-$FF (8bit), $100>=UNSET');
-    STR_USAGE_OPTION_DSPCAC: array[0..1] of string = ('DSP チート全解除', 'DSP cheat ALL clear');
-    STR_USAGE_OPTION_OW: array[0..1] of string = ('SPC 書換', 'Rewrite SPC');
-    STR_USAGE_OPTION_OW_ZC_1: array[0..1] of string = ('エコー作業領域をゼロクリア', 'Zero clear the echo work area');
+    STR_USAGE_OPTION_DSPCAC: array[0..1] of string = ('DSP チート全解除', 'All clear DSP cheats');
+    STR_USAGE_OPTION_OW: array[0..1] of string = ('SPC 書換', 'Rewriting SPC');
+    STR_USAGE_OPTION_OW_ZC_1: array[0..1] of string = ('エコー作業領域をゼロクリア', 'Clear echo work area to $00');
     STR_USAGE_OPTION_OW_ZC_2: array[0..1] of string = ('<IF> = 読込ファイル  <OF> = 書込ファイル', '<IF> = Read path  <OF> = Write path');
-    STR_USAGE_OPTION_EMU: array[0..1] of string = ('SPC 転送エミュレート', 'Emulate SPC Transfer');
-    STR_USAGE_OPTION_EMU_PD_1: array[0..1] of string = ('SHVC-SOUND への転送をエミュレート', 'Emulate transfer to SHVC-SOUND');
+    STR_USAGE_OPTION_EMU: array[0..1] of string = ('SPC 転送シミュレーション', 'SPC transfer simulation');
+    STR_USAGE_OPTION_EMU_PD_1: array[0..1] of string = ('SHVC-SOUND への転送をシミュレート', 'Simulate transfer to SHVC-SOUND');
     STR_USAGE_OPTION_EMU_PD_2: array[0..1] of string = ('<IF> = 読込ファイル', '<IF> = Read path');
     STR_USAGE_OPTION_EMU_PD_3: array[0..1] of string = ('<SF> = Script700 ファイル', '<SF> = Script700 path');
-    STR_USAGE_OPTION_CNV: array[0..1] of string = ('SPC 変換', 'Convert SPC');
-    STR_USAGE_OPTION_CNV_CW_1: array[0..1] of string = ('SPC -> WAVE 変換', 'SPC -> WAVE');
+    STR_USAGE_OPTION_CNV: array[0..1] of string = ('SPC 変換', 'SPC converter');
+    STR_USAGE_OPTION_CNV_CW_1: array[0..1] of string = ('SPC -> WAVE (.wav) 変換', 'SPC -> WAVE (.wav)');
     STR_USAGE_OPTION_CNV_CW_2: array[0..1] of string = ('<IF> = 読込ファイル  <OF> = 書込ファイル', '<IF> = Read path  <OF> = Write path');
     STR_ERROR_008: array[0..1] of string = ('SPCCMD.EXE が起動できません。', 'SPCCMD.EXE cannot open.');
     STR_ERROR_009: array[0..1] of string = ('SPCCMD.EXE が起動できません。', 'SPCCMD.EXE cannot open.');
@@ -431,6 +435,7 @@ function  API_GetFileAttributes(lpFileName: pointer): longword; stdcall; externa
 function  API_GetFileSize(hFile: longword; pFileSizeHigh: pointer): longword; stdcall; external 'kernel32.dll' name 'GetFileSize';
 function  API_GetModuleFileName(hModule: longword; lpFileName: pointer; nSize: longword): longword; stdcall; external 'kernel32.dll' name 'GetModuleFileNameA';
 function  API_GetProcAddress(hModule: longword; lpProcName: pointer): pointer; stdcall; external 'kernel32.dll' name 'GetProcAddress';
+function  API_GetUserDefaultLCID(): longword; stdcall; external 'kernel32.dll' name 'GetUserDefaultLCID';
 function  API_LoadLibrary(lpLibFileName: pointer): longword; stdcall; external 'kernel32.dll' name 'LoadLibraryA';
 function  API_MapFileAndCheckSum(Filename: pointer; HeaderSum: pointer; CheckSum: pointer): longword; stdcall; external 'imagehlp.dll' name 'MapFileAndCheckSumA';
 procedure API_MoveMemory(Destination: pointer; Source: pointer; Length: longword); stdcall; external 'kernel32.dll' name 'RtlMoveMemory';
@@ -782,18 +787,16 @@ begin
     writeln(output, '');
     writeln(output, Concat(' == ', STR_USAGE_OPTION_BP[dwLanguage]));
     writeln(output, Concat('  -bp <XX> <YY> : ', STR_USAGE_OPTION_BP_X[dwLanguage]));
-    writeln(output, Concat('                : ', STR_USAGE_OPTION_BP_Y[dwLanguage]));
-    writeln(output, Concat('  -bpn <XX>     : ', STR_USAGE_OPTION_NEXT[dwLanguage]));
-    writeln(output, Concat('                  ', STR_USAGE_OPTION_NEXT_X[dwLanguage]));
+    writeln(output, Concat('                  ', STR_USAGE_OPTION_BP_Y[dwLanguage]));
+    writeln(output, Concat('  -bpn <ZZ>     : ', STR_USAGE_OPTION_NEXT[dwLanguage]));
+    writeln(output, Concat('                  ', STR_USAGE_OPTION_NEXT_Z[dwLanguage]));
     writeln(output, Concat('                  ', STR_USAGE_OPTION_STOP_FLAGS[dwLanguage]));
     writeln(output, Concat('  -bpc          : ', STR_USAGE_OPTION_BPAC[dwLanguage]));
     writeln(output, '');
     writeln(output, Concat(' == ', STR_USAGE_OPTION_DSPC[dwLanguage]));
     writeln(output, Concat('  -dc <XX> <YY> : ', STR_USAGE_OPTION_DSPC_X[dwLanguage]));
-    writeln(output, Concat('                : ', STR_USAGE_OPTION_DSPC_Y[dwLanguage]));
+    writeln(output, Concat('                  ', STR_USAGE_OPTION_DSPC_Y[dwLanguage]));
     writeln(output, Concat('  -dcc          : ', STR_USAGE_OPTION_DSPCAC[dwLanguage]));
-    writeln(output, '');
-    writeln(output, '');
     writeln(output, '');
     writeln(output, STR_USAGE_NEXT[dwLanguage]);
     readln(input);
@@ -1880,7 +1883,7 @@ begin
     // バッファを解放
     FreeMem(lpBuffer, 1024);
     // 設定を初期化
-    dwLanguage := 0;
+    dwLanguage := LOCALE_AUTO;
     // INI の存在をチェック
     sData := Concat(sChPath, INI_FILE);
     if Exists(pchar(sData), $FFFFFFFF) then begin
@@ -1897,6 +1900,9 @@ begin
         CloseFile(fsFile);
     end;
     // 設定値をチェック
+    if longbool(dwLanguage) then dwLanguage := dwLanguage - 1
+    else if API_GetUserDefaultLCID() and $FFFF = $0411 then dwLanguage := 0
+    else dwLanguage := 1;
     if dwLanguage > 1 then dwLanguage := 0;
     // SPCCMD.EXE の破損を確認
     dwBuffer := GetPosSeparator(sEXEPath);

--- a/spccmd.exe/spccmd.rc
+++ b/spccmd.exe/spccmd.rc
@@ -1,6 +1,6 @@
 1 VERSIONINFO
-    FILEVERSION 1,5,0,4062
-    PRODUCTVERSION 1,5,0,0
+    FILEVERSION 1,5,1,4212
+    PRODUCTVERSION 1,5,1,0
     FILEFLAGSMASK 0x3fL
     FILEFLAGS 0x8L
     FILEOS 0x10004L
@@ -12,10 +12,10 @@ BEGIN
         BLOCK "041103A4"
         BEGIN
             VALUE "FileDescription", "SNES SPC700 Player external command tool\0"
-            VALUE "FileVersion", "1.5.0 (build 4062)\0"
-            VALUE "LegalCopyright", "Copyright (C) 2008-2019 degrade-factory.\0"
+            VALUE "FileVersion", "1.5.1 (build 4212)\0"
+            VALUE "LegalCopyright", "Copyright (C) 2008-2020 degrade-factory.\0"
             VALUE "LegalTrademarks", "SNES is a registered trademark of Nintendo.\0"
-            VALUE "ProductVersion", "1.5.0\0"
+            VALUE "ProductVersion", "1.5.1\0"
             VALUE "URL", "http://dgrfactory.jp/\0"
         END
     END

--- a/spcplay.exe/spcplay.dpr
+++ b/spcplay.exe/spcplay.dpr
@@ -3085,10 +3085,10 @@ const
     TITLE_MAIN_HEADER: array[0..1] of string = (' - ', ' - ');
     TITLE_INFO_HEADER: array[0..1] of string = ('《 ', '< ');
     TITLE_INFO_FOOTER: array[0..1] of string = (' 》', ' >');
-    TITLE_INFO_SEPARATE_HEADER: array[0..1] of string = ('左右拡散度 ', 'Separate = ');
-    TITLE_INFO_FEEDBACK_HEADER: array[0..1] of string = ('フィードバック反転度 ', 'Echo Feedback = ');
-    TITLE_INFO_SPEED_HEADER: array[0..1] of string = ('演奏速度 ', 'Speed = ');
-    TITLE_INFO_AMP_HEADER: array[0..1] of string = ('音量 ', 'Volume = ');
+    TITLE_INFO_SEPARATE_HEADER: array[0..1] of string = ('左右拡散度 ', 'Separate ');
+    TITLE_INFO_FEEDBACK_HEADER: array[0..1] of string = ('フィードバック反転度 ', 'Echo Feedback ');
+    TITLE_INFO_SPEED_HEADER: array[0..1] of string = ('演奏速度 ', 'Speed ');
+    TITLE_INFO_AMP_HEADER: array[0..1] of string = ('音量 ', 'Volume ');
     TITLE_INFO_SEEK_HEADER: array[0..1] of string = ('シーク ', 'Seek ');
     TITLE_INFO_PLUS: array[0..1] of string = ('＋', '+');
     TITLE_INFO_MINUS: array[0..1] of string = ('－', '-');
@@ -9090,16 +9090,16 @@ begin
     if longbool(dwInfo) then begin
         sInfo := Concat(sInfo, TITLE_INFO_HEADER[Status.dwLanguage]);
         case dwInfo of
-            TITLE_INFO_SEPARATE: sInfo := Concat(sInfo, TITLE_INFO_SEPARATE_HEADER[Status.dwLanguage], IntToStr(Status.dwInfo), STR_MENU_SETUP_PERCENT[Status.dwLanguage]);
-            TITLE_INFO_FEEDBACK: sInfo := Concat(sInfo, TITLE_INFO_FEEDBACK_HEADER[Status.dwLanguage], IntToStr(Status.dwInfo), STR_MENU_SETUP_PERCENT[Status.dwLanguage]);
-            TITLE_INFO_SPEED: sInfo := Concat(sInfo, TITLE_INFO_SPEED_HEADER[Status.dwLanguage], IntToStr(Status.dwInfo), STR_MENU_SETUP_PERCENT[Status.dwLanguage]);
-            TITLE_INFO_AMP: sInfo := Concat(sInfo, TITLE_INFO_AMP_HEADER[Status.dwLanguage], IntToStr(Status.dwInfo), STR_MENU_SETUP_PERCENT[Status.dwLanguage]);
+            TITLE_INFO_SEPARATE: sInfo := Concat(sInfo, TITLE_INFO_SEPARATE_HEADER[Status.dwLanguage], IntToStr(Status.dwInfo), ' ', STR_MENU_SETUP_PERCENT[Status.dwLanguage]);
+            TITLE_INFO_FEEDBACK: sInfo := Concat(sInfo, TITLE_INFO_FEEDBACK_HEADER[Status.dwLanguage], IntToStr(Status.dwInfo), ' ', STR_MENU_SETUP_PERCENT[Status.dwLanguage]);
+            TITLE_INFO_SPEED: sInfo := Concat(sInfo, TITLE_INFO_SPEED_HEADER[Status.dwLanguage], IntToStr(Status.dwInfo), ' ', STR_MENU_SETUP_PERCENT[Status.dwLanguage]);
+            TITLE_INFO_AMP: sInfo := Concat(sInfo, TITLE_INFO_AMP_HEADER[Status.dwLanguage], IntToStr(Status.dwInfo), ' ', STR_MENU_SETUP_PERCENT[Status.dwLanguage]);
             TITLE_INFO_SEEK: begin
                 sInfo := Concat(sInfo, TITLE_INFO_SEEK_HEADER[Status.dwLanguage]);
                 if Status.dwInfo >= 0 then sInfo := Concat(sInfo, TITLE_INFO_PLUS[Status.dwLanguage])
                 else sInfo := Concat(sInfo, TITLE_INFO_MINUS[Status.dwLanguage]);
                 if longbool(Abs(Status.dwInfo) mod 1000) then sInfo := Concat(sInfo, IntToStr(Abs(Status.dwInfo)), STR_MENU_SETUP_MSEC[Status.dwLanguage])
-                else sInfo := Concat(sInfo, IntToStr(longword(Trunc(Abs(Status.dwInfo) / 1000))), STR_MENU_SETUP_SEC1[Status.dwLanguage]);
+                else sInfo := Concat(sInfo, IntToStr(longword(Trunc(Abs(Status.dwInfo) / 1000))), ' ', STR_MENU_SETUP_SEC1[Status.dwLanguage]);
             end;
         end;
         sInfo := Concat(sInfo, TITLE_INFO_FOOTER[Status.dwLanguage], TITLE_MAIN_HEADER[Status.dwLanguage]);

--- a/spcplay.exe/spcplay.dpr
+++ b/spcplay.exe/spcplay.dpr
@@ -852,6 +852,7 @@ type
         cmSetupOption: CMENU;                               // メニュー クラス (設定 - 拡張設定)
         cmSetupTime: CMENU;                                 // メニュー クラス (設定 - 演奏時間)
         cmSetupOrder: CMENU;                                // メニュー クラス (設定 - 演奏順序)
+        cmSetupSeek: CMENU;                                 // メニュー クラス (設定 - シーク時間)
         cmSetupInfo: CMENU;                                 // メニュー クラス (設定 - 情報表示)
         cmSetupPriority: CMENU;                             // メニュー クラス (設定 - 基本優先度)
         cmList: CMENU;                                      // メニュー クラス (プレイリスト)
@@ -2325,8 +2326,8 @@ const
     DEFAULT_TITLE: string = 'SNES SPC700 Player';
     SPCPLAY_TITLE = '[ SNES SPC700 Player   ]' + CRLF + ' SPCPLAY.EXE v';
     SNESAPU_TITLE = '[ SNES SPC700 Emulator ]' + CRLF + ' SNESAPU.DLL v';
-    SPCPLAY_VERSION = '2.18.0 (build 6694)';
-    SNESAPU_VERSION = $21800;
+    SPCPLAY_VERSION = '2.18.1 (build 6862)';
+    SNESAPU_VERSION = $21861;
     APPLINK_VERSION = $02170500;
 
     CBE_DSPREG = $1;
@@ -2851,15 +2852,19 @@ const
     MENU_SETUP_ORDER = 61;
     MENU_SETUP_ORDER_SIZE = 6;
     MENU_SETUP_ORDER_BASE = 610;
-    MENU_SETUP_INFO = 62;
+    MENU_SETUP_SEEK = 62;
+    MENU_SETUP_SEEK_SIZE = 5;
+    MENU_SETUP_SEEK_BASE = 620; // +10
+    MENU_SETUP_SEEK_VALUE: array[0..MENU_SETUP_SEEK_SIZE - 1] of longword = (1000, 2000, 3000, 4000, 5000);
+    MENU_SETUP_INFO = 63;
     MENU_SETUP_INFO_SIZE = 9;
-    MENU_SETUP_INFO_BASE = 620;
-    MENU_SETUP_INFO_RESET = 619;
-    MENU_SETUP_PRIORITY = 63;
+    MENU_SETUP_INFO_BASE = 630;
+    MENU_SETUP_INFO_RESET = 629;
+    MENU_SETUP_PRIORITY = 64;
     MENU_SETUP_PRIORITY_SIZE = 6;
-    MENU_SETUP_PRIORITY_BASE = 630;
+    MENU_SETUP_PRIORITY_BASE = 640;
     MENU_SETUP_PRIORITY_VALUE: array[0..MENU_SETUP_PRIORITY_SIZE - 1] of longword = (REALTIME_PRIORITY_CLASS, HIGH_PRIORITY_CLASS, ABOVE_NORMAL_PRIORITY_CLASS, NORMAL_PRIORITY_CLASS, BELOW_NORMAL_PRIORITY_CLASS, IDLE_PRIORITY_CLASS);
-    MENU_SETUP_TOPMOST = 640;
+    MENU_SETUP_TOPMOST = 650;
     MENU_LIST_PLAY = 700;
     MENU_LIST_PLAY_SELECT = 701;
     MENU_LIST_PLAY_SIZE = 6;
@@ -2984,17 +2989,18 @@ const
     STR_MENU_SETUP_MUTE: array[0..1] of pchar = ('チャンネル ミュート(&M)', 'Channel &Mute');
     STR_MENU_SETUP_NOISE: array[0..1] of pchar = ('チャンネル ノイズ(&N)', 'Channel &Noise');
     STR_MENU_SETUP_SWITCH_CHANNEL: array[0..1] of pchar = ('チャンネル ', 'Channel ');
-    STR_MENU_SETUP_OPTION: array[0..1] of pchar = ('拡張設定(&X)', 'E&xpansion');
+    STR_MENU_SETUP_OPTION: array[0..1] of pchar = ('拡張設定(&X)', 'E&xpansion Flags');
     STR_MENU_SETUP_TIME: array[0..1] of pchar = ('演奏時間(&T)', 'Play &Time');
     STR_MENU_SETUP_TIME_DISABLE: array[0..1] of pchar = ('無効(&D)', '&Disable');
     STR_MENU_SETUP_TIME_ID666: array[0..1] of pchar = ('&ID666 設定値を使用', 'Enable &ID666 Time');
     STR_MENU_SETUP_TIME_DEFAULT: array[0..1] of pchar = ('デフォルト値を使用(&E)', '&Enable Default Time');
-    STR_MENU_SETUP_TIME_START: array[0..1] of pchar = ('開始位置を設定(&S)', 'Set &Start Mark');
-    STR_MENU_SETUP_TIME_LIMIT: array[0..1] of pchar = ('終了位置を設定(&L)', 'Set &Limit Mark');
-    STR_MENU_SETUP_TIME_RESET: array[0..1] of pchar = ('位置をリセット(&R)', '&Reset Mark');
+    STR_MENU_SETUP_TIME_START: array[0..1] of pchar = ('開始位置を設定(&S)', 'Set &Start Position Mark');
+    STR_MENU_SETUP_TIME_LIMIT: array[0..1] of pchar = ('終了位置を設定(&L)', 'Set &Limit Position Mark');
+    STR_MENU_SETUP_TIME_RESET: array[0..1] of pchar = ('位置をリセット(&R)', '&Reset Position Marks');
     STR_MENU_SETUP_ORDER: array[0..1] of pchar = ('演奏順序(&O)', 'Play &Order');
     STR_MENU_SETUP_INFO: array[0..1] of pchar = ('情報表示(&A)', 'I&nformation Viewer');
-    STR_MENU_SETUP_INFO_RESET: array[0..1] of pchar = ('無音チャンネル非表示(&H)', '&Hide Mute Channel');
+    STR_MENU_SETUP_INFO_RESET: array[0..1] of pchar = ('無音チャンネル非表示(&H)', '&Hide Muted Channels');
+    STR_MENU_SETUP_SEEK: array[0..1] of pchar = ('シーク時間(&K)', 'See&k Time');
     STR_MENU_SETUP_PRIORITY: array[0..1] of pchar = ('処理優先度(&U)', 'CP&U Priority');
     STR_MENU_SETUP_TOPMOST: array[0..1] of pchar = ('常に手前に表示(&W)', 'Al&ways on Top');
     STR_MENU_LIST_PLAY: array[0..1] of pchar = ('演奏開始(&P)', '&Play');
@@ -3041,14 +3047,19 @@ const
     STR_MENU_SETUP_INFO_SUB: array[0..1] of array[0..MENU_SETUP_INFO_SIZE - 1] of pchar = (
         ('グラフィック インジケータ(&G)', 'ミキサー情報(&M)', 'チャンネル情報 1 (&C)', 'チャンネル情報 2 (&A)', 'チャンネル情報 3 (&N)', 'チャンネル情報 4 (&E)', '&SPC 情報 1', 'S&PC 情報 2', 'Script&700 デバッグ'),
         ('&Graphic Indicator', '&Mixer', '&Channel 1', 'Ch&annel 2', 'Cha&nnel 3', 'Chann&el 4', '&SPC Tags 1', 'S&PC Tags 2', 'Script&700 Debug'));
+    STR_MENU_SETUP_SEEK_SUB: array[0..1] of array[0..MENU_SETUP_SEEK_SIZE - 1] of pchar = (
+        ('&1 秒', '&2 秒', '&3 秒', '&4 秒', '&5 秒'),
+        ('&1 s', '&2 s', '&3 s', '&4 s', '&5 s'));
     STR_MENU_SETUP_PRIORITY_SUB: array[0..1] of array[0..MENU_SETUP_PRIORITY_SIZE - 1] of pchar = (
         ('リアルタイム(&R)', '高(&H)', '標準以上(&A)', '標準(&N)', '標準以下(&B)', '低(&L)'),
         ('&Realtime', '&High', '&Above Normal', '&Normal', '&Below Normal', '&Low'));
     STR_MENU_LIST_PLAY_SUB: array[0..1] of array[0..MENU_LIST_PLAY_SIZE - 1] of pchar = (
         ('次へ(&N)', '前へ(&P)', 'ランダム(&M)', 'シャッフル(&H)', '最初から(&F)', '最後から(&L)'),
         ('&Next Item', '&Previous Item', 'Rando&m', 'S&huffle', '&First Item', '&Last Item'));
-    STR_MENU_SETUP_PERCENT: array[0..1] of string = (' ％', ' %');
-    STR_MENU_SETUP_MSEC: array[0..1] of string = (' ms', ' ms');
+    STR_MENU_SETUP_PERCENT: array[0..1] of string = ('％', '%');
+    STR_MENU_SETUP_SEC1: array[0..1] of string = ('秒', 's');
+    STR_MENU_SETUP_SEC2: array[0..1] of string = ('sec', 's  ');
+    STR_MENU_SETUP_MSEC: array[0..1] of string = ('ms', 'ms');
     STR_BUTTON_OPEN = 'OPEN';
     STR_BUTTON_SAVE = 'SAVE';
     STR_BUTTON_PLAY = 'PLAY';
@@ -5090,7 +5101,7 @@ begin
     cmMenu.CreatePopupMenu();
     // メニュー テキストを設定
     for I := 0 to nSize - 1 do begin
-        sBuffer := Concat('&', IntToStr(STR_MENU_SETUP_PER_INTEGER[PerIndex[I]]), STR_MENU_SETUP_PERCENT[Status.dwLanguage]);
+        sBuffer := Concat('&', IntToStr(STR_MENU_SETUP_PER_INTEGER[PerIndex[I]]), ' ', STR_MENU_SETUP_PERCENT[Status.dwLanguage]);
         if longbool(TipIndex[I]) then sBuffer := Concat(sBuffer, #9, STR_MENU_SETUP_TIP[Status.dwLanguage][TipIndex[I]]);
         cmMenu.AppendMenu(dwBase + I, pchar(sBuffer), true);
     end;
@@ -5591,6 +5602,8 @@ begin
     cmSetupTime.AppendMenu(MENU_SETUP_TIME_RESET, STR_MENU_SETUP_TIME_RESET[Status.dwLanguage]);
     // 演奏順序メニューを作成
     SetMenuTextAndTip(cmSetupOrder, MENU_SETUP_ORDER_SIZE, MENU_SETUP_ORDER_BASE, STR_MENU_SETUP_ORDER_SUB[Status.dwLanguage], true);
+    // シーク時間メニューを作成
+    SetMenuTextAndTip(cmSetupSeek, MENU_SETUP_SEEK_SIZE, MENU_SETUP_SEEK_BASE, STR_MENU_SETUP_SEEK_SUB[Status.dwLanguage], true);
     // 情報表示メニューを作成
     SetMenuTextAndTip(cmSetupInfo, MENU_SETUP_INFO_SIZE, MENU_SETUP_INFO_BASE, STR_MENU_SETUP_INFO_SUB[Status.dwLanguage], true);
     cmSetupInfo.AppendSeparator();
@@ -5617,6 +5630,7 @@ begin
     cmSetup.AppendSeparator();
     cmSetup.AppendMenu(MENU_SETUP_TIME, STR_MENU_SETUP_TIME[Status.dwLanguage], cmSetupTime.hMenu);
     cmSetup.AppendMenu(MENU_SETUP_ORDER, STR_MENU_SETUP_ORDER[Status.dwLanguage], cmSetupOrder.hMenu);
+    cmSetup.AppendMenu(MENU_SETUP_SEEK, STR_MENU_SETUP_SEEK[Status.dwLanguage], cmSetupSeek.hMenu);
     cmSetup.AppendMenu(MENU_SETUP_INFO, STR_MENU_SETUP_INFO[Status.dwLanguage], cmSetupInfo.hMenu);
     cmSetup.AppendMenu(MENU_SETUP_PRIORITY, STR_MENU_SETUP_PRIORITY[Status.dwLanguage], cmSetupPriority.hMenu);
     cmSetup.AppendSeparator();
@@ -5829,7 +5843,6 @@ begin
     Writeln(fsFile, Concat(BUFFER_SEEKINT_, IntToStr(Option.dwSeekInt)));
     Writeln(fsFile, Concat(BUFFER_SEEKMAX_, IntToStr(Option.dwSeekMax)));
     Writeln(fsFile, Concat(BUFFER_SEEKNUM_, IntToStr(Option.dwSeekNum)));
-    Writeln(fsFile, Concat(BUFFER_SEEKTIME, IntToStr(Option.dwSeekTime)));
     Writeln(fsFile, Concat(BUFFER_SPEEDTUN, IntToStr(Option.dwSpeedTun)));
     Writeln(fsFile, Concat(BUFFER_VOLCOLOR, IntToStr(Option.dwVolumeColor)));
     Writeln(fsFile, Concat(BUFFER_VOLSPEED, IntToStr(Option.dwVolumeSpeed)));
@@ -5856,6 +5869,7 @@ begin
     Writeln(fsFile, Concat(BUFFER_PLAYTYPE, IntToStr(Option.dwPlayOrder)));
     Writeln(fsFile, Concat(BUFFER_PRIORITY, IntToStr(Option.dwPriority)));
     Writeln(fsFile, Concat(BUFFER_RATE____, IntToStr(Option.dwRate)));
+    Writeln(fsFile, Concat(BUFFER_SEEKTIME, IntToStr(Option.dwSeekTime)));
     Writeln(fsFile, Concat(BUFFER_SEPARATE, IntToStr(Option.dwSeparate)));
     Writeln(fsFile, Concat(BUFFER_SPEED___, IntToStr(Option.dwSpeedBas)));
     Writeln(fsFile, Concat(BUFFER_TOP_____, IntToStr(NormalRect.top + ScreenRect.top)));
@@ -5923,6 +5937,8 @@ begin
     cmSetupTime.Free();
     cmSetupOrder.DeleteMenu();
     cmSetupOrder.Free();
+    cmSetupSeek.DeleteMenu();
+    cmSetupSeek.Free();
     cmSetupInfo.DeleteMenu();
     cmSetupInfo.Free();
     cmSetupPriority.DeleteMenu();
@@ -8865,7 +8881,7 @@ begin
                 INFO_CHANNEL_4: sInfo := Concat(sInfo, CRLF, '    Src Addr Loop Read       Src Addr Loop Read');
             end;
             case Option.dwInfo of
-                INFO_MIXER: sInfo := Concat(sInfo, CRLF, 'MasterLv : L=    R=      EchoLv   : L=    R=', CRLF, 'Delay    :    (   ', STR_MENU_SETUP_MSEC[Status.dwLanguage], ')   Feedback :    (   ', STR_MENU_SETUP_PERCENT[Status.dwLanguage], ')', CRLF, 'SrcAddr  :     -   _     EchoAddr :     -', CRLF, 'DSPFlags : R=  M=  E=    NoiseClk :       Hz', CRLF, 'FIR      :');
+                INFO_MIXER: sInfo := Concat(sInfo, CRLF, 'MasterLv : L=    R=      EchoLv   : L=    R=', CRLF, 'Delay    :    (    ms)   Feedback :    (    ', STR_MENU_SETUP_PERCENT[Status.dwLanguage], ')', CRLF, 'SrcAddr  :     -   _     EchoAddr :     -', CRLF, 'DSPFlags : R=  M=  E=    NoiseClk :       Hz', CRLF, 'FIR      :');
                 INFO_CHANNEL_1, INFO_CHANNEL_2, INFO_CHANNEL_3, INFO_CHANNEL_4: sInfo := Concat(sInfo, CRLF, '1 :                      5 :', CRLF, '2 :                      6 :', CRLF, '3 :                      7 :', CRLF, '4 :                      8 :');
                 INFO_SCRIPT700: sInfo := Concat(sInfo, CRLF, 'Port  In :               Out :', CRLF, 'Work 0-3 :', CRLF, '     4-7 :', CRLF, 'CmpParam :                     Wait :', CRLF, 'UsedSize :        (Ptr=      Data=      SP=   )');
             end;
@@ -8887,9 +8903,9 @@ begin
             if not bytebool(Spc.Hdr.TagFormat) or not longbool(Spc.Hdr.dwSongLen) then sInfo := Concat(sInfo, '(Unknown)')
             else begin
                 sBuffer := IntToStr(Spc.Hdr.dwSongLen);
-                sInfo := Concat(sInfo, sBuffer, ' sec', StringOfChar(' ', 10 - Length(sBuffer)));
+                sInfo := Concat(sInfo, sBuffer, ' ', STR_MENU_SETUP_SEC2[Status.dwLanguage], StringOfChar(' ', 10 - Length(sBuffer)));
                 if not longbool(Spc.Hdr.dwFadeLen) then sInfo := Concat(sInfo, '(No Fadeout)')
-                else sInfo := Concat(sInfo, 'FadeTime : ', IntToStr(Spc.Hdr.dwFadeLen), ' ms');
+                else sInfo := Concat(sInfo, 'FadeTime : ', IntToStr(Spc.Hdr.dwFadeLen), ' ', STR_MENU_SETUP_MSEC[Status.dwLanguage]);
             end;
         end;
         INFO_SPC_2: begin
@@ -9001,6 +9017,7 @@ begin
     cmSetupTime.SetMenuEnable(MENU_SETUP_TIME_LIMIT, Status.bPlay and Option.bPlayTime);
     cmSetupTime.SetMenuEnable(MENU_SETUP_TIME_RESET, Status.bOpen and Status.bTimeRepeat);
     for I := 0 to MENU_SETUP_ORDER_SIZE - 1 do cmSetupOrder.SetMenuCheck(MENU_SETUP_ORDER_BASE + I, Option.dwPlayOrder = longword(I));
+    for I := 0 to MENU_SETUP_SEEK_SIZE - 1 do cmSetupSeek.SetMenuCheck(MENU_SETUP_SEEK_BASE + I, Option.dwSeekTime = MENU_SETUP_SEEK_VALUE[I]);
     for I := 0 to MENU_SETUP_INFO_SIZE - 1 do cmSetupInfo.SetMenuCheck(MENU_SETUP_INFO_BASE + I, Option.dwInfo = longword(I));
     cmSetupInfo.SetMenuCheck(MENU_SETUP_INFO_RESET, Option.bVolumeReset);
     for I := 0 to MENU_SETUP_PRIORITY_SIZE - 1 do begin
@@ -9058,7 +9075,6 @@ procedure CWINDOWMAIN.UpdateTitle(dwFlag: longword);
 var
     dwInfo: longword;
     sInfo: string;
-    sPlus: string;
 begin
     // タイトルを更新しない場合は終了
     if not longbool(Status.dwTitle) then exit;
@@ -9079,9 +9095,11 @@ begin
             TITLE_INFO_SPEED: sInfo := Concat(sInfo, TITLE_INFO_SPEED_HEADER[Status.dwLanguage], IntToStr(Status.dwInfo), STR_MENU_SETUP_PERCENT[Status.dwLanguage]);
             TITLE_INFO_AMP: sInfo := Concat(sInfo, TITLE_INFO_AMP_HEADER[Status.dwLanguage], IntToStr(Status.dwInfo), STR_MENU_SETUP_PERCENT[Status.dwLanguage]);
             TITLE_INFO_SEEK: begin
-                if Status.dwInfo >= 0 then sPlus := TITLE_INFO_PLUS[Status.dwLanguage]
-                else sPlus := TITLE_INFO_MINUS[Status.dwLanguage];
-                sInfo := Concat(sInfo, TITLE_INFO_SEEK_HEADER[Status.dwLanguage], sPlus, IntToStr(Abs(Status.dwInfo)), STR_MENU_SETUP_MSEC[Status.dwLanguage]);
+                sInfo := Concat(sInfo, TITLE_INFO_SEEK_HEADER[Status.dwLanguage]);
+                if Status.dwInfo >= 0 then sInfo := Concat(sInfo, TITLE_INFO_PLUS[Status.dwLanguage])
+                else sInfo := Concat(sInfo, TITLE_INFO_MINUS[Status.dwLanguage]);
+                if longbool(Abs(Status.dwInfo) mod 1000) then sInfo := Concat(sInfo, IntToStr(Abs(Status.dwInfo)), STR_MENU_SETUP_MSEC[Status.dwLanguage])
+                else sInfo := Concat(sInfo, IntToStr(longword(Trunc(Abs(Status.dwInfo) / 1000))), STR_MENU_SETUP_SEC1[Status.dwLanguage]);
             end;
         end;
         sInfo := Concat(sInfo, TITLE_INFO_FOOTER[Status.dwLanguage], TITLE_MAIN_HEADER[Status.dwLanguage]);
@@ -10021,6 +10039,7 @@ begin
                             // インジケータを再描画
                             cwWindowMain.PostMessage(WM_APP_MESSAGE, WM_APP_REDRAW, NULL);
                         end;
+                        MENU_SETUP_SEEK_BASE: Option.dwSeekTime := MENU_SETUP_SEEK_VALUE[wParam - MENU_SETUP_SEEK_BASE];
                         MENU_SETUP_INFO_BASE: begin
                             SetChangeInfo(true, wParam - MENU_SETUP_INFO_BASE);
                             exit; // UpdateMenu を実行しない

--- a/spcplay.exe/spcplay.rc
+++ b/spcplay.exe/spcplay.rc
@@ -2,8 +2,8 @@ MAINICON ICON DISCARDABLE "spcplay.ico"
 MAINBMP BITMAP DISCARDABLE "spcplay.bmp"
 
 1 VERSIONINFO
-    FILEVERSION 2,18,0,6694
-    PRODUCTVERSION 2,18,0,0
+    FILEVERSION 2,18,1,6862
+    PRODUCTVERSION 2,18,1,0
     FILEFLAGSMASK 0x3fL
     FILEFLAGS 0x8L
     FILEOS 0x10004L
@@ -15,11 +15,11 @@ BEGIN
         BLOCK "041103A4"
         BEGIN
             VALUE "FileDescription", "SNES SPC700 Player\0"
-            VALUE "FileVersion", "2.18.0 (build 6694)\0"
-            VALUE "LegalCopyright", "Copyright (C) 2003-2019 degrade-factory.\0"
+            VALUE "FileVersion", "2.18.1 (build 6862)\0"
+            VALUE "LegalCopyright", "Copyright (C) 2003-2020 degrade-factory.\0"
             VALUE "LegalTrademarks", "SNES is a registered trademark of Nintendo.\0"
             VALUE "ProductName", "SPCPLAY\0"
-            VALUE "ProductVersion", "2.18.0\0"
+            VALUE "ProductVersion", "2.18.1\0"
             VALUE "URL", "http://dgrfactory.jp/\0"
         END
     END


### PR DESCRIPTION
spcplay.exe
* [設定] に [シーク時間] メニューを追加。
* シーク時間が秒単位の場合は、秒表示に変更。

snesapu.dll
* v2.18.0 で、一部の曲において冒頭の音が鳴らない不具合を修正。
* 一部処理を最適化。

spccmd.exe
* SPCPLAY.EXE v2.18.0 の言語設定が適用されない不具合を修正。