### PR TITLE
Implement main sound output toggle

### DIFF
--- a/snesapu.dll/DSP.asm
+++ b/snesapu.dll/DSP.asm
@@ -23,6 +23,7 @@
 ;
 ;List of users and dates who/when modified this file:
 ;   - degrade-factory in 2024-01-18
+;   - Zenith in 2024-06-19
 ;===================================================================================================
 
 CPU     386
@@ -5047,7 +5048,10 @@ PROC RunDSP
     Mov     ESI,mixBuf
 
     .NextSmp:
-        MixMaster
+        Test    dword [dspOpts],DSP_NOMAIN                                      ;Is main output disabled?
+        JNZ     .NoMain                                                         ;   Yes
+            MixMaster
+        .NoMain:
 
         Test    byte [disFlag],30h                                              ;Is echo disabled by DSP? (disFlag = [4][5])
         JNZ     .NoEchoDSP                                                      ;   Yes

--- a/snesapu.dll/DSP.h
+++ b/snesapu.dll/DSP.h
@@ -23,6 +23,7 @@
 *                                                                                                  *
 * List of users and dates who/when modified this file:                                             *
 *    - degrade-factory in 2024-01-18                                                               *
+*    - Zenith in 2024-06-19                                                                        *
 ***************************************************************************************************/
 
 #ifndef __INC_DSP
@@ -66,6 +67,7 @@
 #define DSP_NOSURND 0x1000                      //Disable surround sound
 #define DSP_ENVSPD  0x2000                      //Synchronize envelope updates with speed
 #define DSP_NOPLMT  0x4000                      //Disable the maximum pitch limit
+#define DSP_NOMAIN  0x8000                      //Disable main output, leaving only echo
 #define DSP_FLOAT   0x40000000                  //32bit floating-point volume output
 #define DSP_NOSAFE  0x80000000                  //Disable volume safe
 

--- a/snesapu.dll/DSP.inc
+++ b/snesapu.dll/DSP.inc
@@ -23,6 +23,7 @@
 ;
 ;List of users and dates who/when modified this file:
 ;   - degrade-factory in 2024-01-18
+;   - Zenith in 2024-06-19
 ;===================================================================================================
 
 %define DSP_INC
@@ -65,6 +66,7 @@ DSP_ECHOFIR EQU 800h                                            ;Simulate SNES e
 DSP_NOSURND EQU 1000h                                           ;Disable surround sound
 DSP_ENVSPD  EQU 2000h                                           ;Synchronize envelope updates with speed
 DSP_NOPLMT  EQU 4000h                                           ;Disable the maximum pitch limit
+DSP_NOMAIN  EQU 8000h                                           ;Disable main output, leaving only echo
 DSP_FLOAT   EQU 40000000h                                       ;32bit floating-point volume output
 DSP_NOSAFE  EQU 80000000h                                       ;Disable volume safe
 

--- a/snesapu.dll/SNESAPU.inc
+++ b/snesapu.dll/SNESAPU.inc
@@ -31,4 +31,4 @@
 ;     so that the lower 8-bits of the start address of '_mix' are '00'.
 ;    If it is not, the output audio will be noisy because occurred memory-leak.
 ;    The value specified here is 0, 64, 128, or 192.
-DSP_ALIGN   EQU 192                                             ;DSP Object Locate Alignment
+DSP_ALIGN   EQU 0                                               ;DSP Object Locate Alignment

--- a/spcplay.exe/spcplay.dpr
+++ b/spcplay.exe/spcplay.dpr
@@ -3177,6 +3177,7 @@ const
     OPTION_NOSURROUND = $1000;                              // サラウンド無効
     OPTION_ENVSPEED = $2000;                                // エンベロープ速度比を同期
     OPTION_NOPLIMIT = $4000;                                // ピッチ制限無効
+    OPTION_NOMAIN = $8000;                                  // メイン無効
     OPTION_FLOATOUT = $40000000;                            // 32 ビット (float) で出力レベルを設定
     OPTION_NOEARSAFE = $80000000;                           // イヤーセーフ無効
 
@@ -3271,12 +3272,12 @@ const
     MENU_SETUP_MUTE_NOISE_SIZE = 8;
     MENU_SETUP_MUTE_NOISE_ALL_SIZE = 3;
     MENU_SETUP_OPTION = 50;
-    MENU_SETUP_OPTION_SIZE = 17;
+    MENU_SETUP_OPTION_SIZE = 18;
     MENU_SETUP_OPTION_BASE = 500; // +10
     MENU_SETUP_OPTION_VALUE: array[0..MENU_SETUP_OPTION_SIZE - 1] of longword =
         (OPTION_LOWPASS, OPTION_ECHOFIR, NULL, OPTION_BASSBOOST, OPTION_OLDSMP, OPTION_SURROUND, OPTION_REVERSE, OPTION_ENVSPEED,
-         NULL, OPTION_NOSURROUND, OPTION_NOECHO, OPTION_NOFIR, OPTION_NOPMOD, OPTION_NOPREAD, OPTION_NOPLIMIT, OPTION_NOENV,
-         OPTION_NONOISE);
+         NULL, OPTION_NOSURROUND, OPTION_NOMAIN, OPTION_NOECHO, OPTION_NOFIR, OPTION_NOPMOD, OPTION_NOPREAD, OPTION_NOPLIMIT,
+         OPTION_NOENV, OPTION_NONOISE);
     MENU_SETUP_TIME = 60;
     MENU_SETUP_TIME_DISABLE = 600;
     MENU_SETUP_TIME_ID666 = 601;
@@ -3509,12 +3510,12 @@ const
         ('標準(&N)', '過去の &Sound Blaster 互換', '過去の &ZSNES, Snes9x 互換'),
         ('&Normal', 'OLD &Sound Blaster Card', 'OLD &ZSNES, Snes9x'));
     STR_MENU_SETUP_OPTION_SUB: array[0..1] of array[0..MENU_SETUP_OPTION_SIZE - 1] of pchar = (
-        ('実機ローパス フィルタ(&L)', '実機エコー/FIR 処理(&M)', NULLPOINTER, '&BASS BOOST', '過去の &ADPCM デコーダ', '逆位相サラウンド強制(&S)',
-         '左右反転(&R)', 'エンベロープ速度比を同期(&Y)', NULLPOINTER, 'サラウンド無効(&U)', 'エコー無効(&E)', '&FIR フィルタ無効',
-         'ピッチ モジュレーション無効(&P)', 'ピッチ ベンド無効(&I)', 'ピッチ リミット無効(&T)', 'エンベロープ無効(&V)', 'ノイズ発音指定無効(&N)'),
-        ('SNES &Low-Pass Filter', 'SNES Echo/FIR &Method', NULLPOINTER, '&BASS BOOST', 'Old &ADPCM Decoder', 'Opposite-Phase &Surround',
-         '&Reverse Stereo', 'S&ynchronize Envelope with Speed', NULLPOINTER, 'Disable S&urround', 'Disable &Echo', 'Disable &FIR Filter',
-         'Disable &Pitch Modulation', 'Disable P&itch Bend', 'Disable Pi&tch Limit', 'Disable En&velope', 'Disable &Noise Flags'));
+        ('実機ローパス フィルタ(&L)', '実機エコー/FIR 処理(&C)', NULLPOINTER, '&BASS BOOST', '過去の &ADPCM デコーダ', '逆位相サラウンド強制(&S)',
+         '左右反転(&R)', 'エンベロープ速度比を同期(&Y)', NULLPOINTER, 'サラウンド無効(&U)', 'メイン無効(&M)', 'エコー無効(&E)',
+         '&FIR フィルタ無効', 'ピッチ モジュレーション無効(&P)', 'ピッチ ベンド無効(&I)', 'ピッチ リミット無効(&T)', 'エンベロープ無効(&V)', 'ノイズ発音指定無効(&N)'),
+        ('SNES &Low-Pass Filter', 'SNES E&cho/FIR Method', NULLPOINTER, '&BASS BOOST', 'Old &ADPCM Decoder', 'Opposite-Phase &Surround',
+         '&Reverse Stereo', 'S&ynchronize Envelope with Speed', NULLPOINTER, 'Disable S&urround', 'Disable &Main', 'Disable &Echo',
+         'Disable &FIR Filter', 'Disable &Pitch Modulation', 'Disable P&itch Bend', 'Disable Pi&tch Limit', 'Disable En&velope', 'Disable &Noise Flags'));
     STR_MENU_SETUP_ORDER_SUB: array[0..1] of array[0..MENU_SETUP_ORDER_SIZE - 1] of pchar = (
         ('演奏停止(&S)', '次へ(&N)', '前へ(&P)', 'ランダム(&M)', 'シャッフル(&H)', 'リピート(&R)'),
         ('&Stop', '&Next Item', '&Previous Item', 'Rando&m', 'S&huffle', '&Repeat'));


### PR DESCRIPTION
Useful for investigating the echo channel outputs in isolation.

![spcplay-nomain-eng](https://github.com/dgrfactory/spcplay/assets/57304287/d992ccd4-2488-4b12-bfee-ea431490ee15)
![spcplay-nomain-jpn](https://github.com/dgrfactory/spcplay/assets/57304287/b734f7e0-2642-4180-be25-bc32c27d388e)

I'm willing to change anything if changes must be made; just let me know. I added the Japanese text as well (using Google Translate). Hopefully, it is correct. Unfortunately, the shortcut is mapped to `M`, which is the same as `SNES Echo/FIR &Method`. Not sure what character could be more applicable for this option or if this is a problem at all. I saw you were careful in not using duplicate shortcut characters, so I thought, "Hmm... What about changing 'Main' to 'Primary'?'' But `P` is also taken already by `Disable &Pitch Modulation`.